### PR TITLE
typos on sounder_freq_count variable name

### DIFF
--- a/qnx4/interleavesound.1.00/interleavesound.c
+++ b/qnx4/interleavesound.1.00/interleavesound.c
@@ -188,8 +188,8 @@ int main(int argc,char *argv[]) {
   if (snd_dat != NULL) {
     fscanf(snd_dat, "%d", &sounder_freqs_total);
     if (sounder_freqs_total > 12) sounder_freqs_total=12;
-    for (sounder_freq_count=0; sounder_freq_count < sounder_freqs_total; sounder_freq_cnt++)
-      fscanf(snd_dat, "%d", &sounder_freqs[sounder_freq_cnt]);
+    for (sounder_freq_count=0; sounder_freq_count < sounder_freqs_total; sounder_freq_count++)
+      fscanf(snd_dat, "%d", &sounder_freqs[sounder_freq_count]);
     sounder_freq_count=0;
     fclose(snd_dat);
   }


### PR DESCRIPTION
Found a few typos on the variable name that was keeping this code from compiling at Kapukasing.  This is untested though, but at least it compiles now.