### PR TITLE
Decrease number of ranges during sounding scans

### DIFF
--- a/qnx4/interleavesound.1.00/interleavesound.c
+++ b/qnx4/interleavesound.1.00/interleavesound.c
@@ -45,6 +45,10 @@
 
 /*
  $Log: interleavesound.c,v $
+ Revision 1.1  2021/09/15 egthomas
+ Modification to set number of ranges used for frequency
+ sounding independently of nrang for the interleaved scan
+
  Revision 1.0  2019/06/14 egthomas
  Initial revision from interleavedscan and normalsound
  
@@ -57,7 +61,7 @@
 #define TASK_NAMES "echo_data","iqwrite","rawacfwrite","fitacfwrite"
 
 char cmdlne[1024];
-char progid[80]={"$Id: interleavesound.c,v 1.0 2019/06/14 egthomas Exp $"};
+char progid[80]={"$Id: interleavesound.c,v 1.1 2021/09/15 egthomas Exp $"};
 char progname[256];
 struct TaskID *errlog;
 

--- a/qnx4/interleavesound.1.00/interleavesound.c
+++ b/qnx4/interleavesound.1.00/interleavesound.c
@@ -531,7 +531,7 @@ int main(int argc,char *argv[]) {
         if (exitpoll !=0) break;
 
         if (limit_fswitch) {
-          /* check for the end of a frequency loop */
+          /* check for the end of a frequency loop (optional) */
           snd_bm_cnt++;
           if (snd_bm_cnt >= snd_bms_tot) {
             /* reset the beam counter and increment the freq counter */

--- a/qnx4/interleavesound.1.00/interleavesound.c
+++ b/qnx4/interleavesound.1.00/interleavesound.c
@@ -505,7 +505,7 @@ int main(int argc,char *argv[]) {
         /* Only send these to echo_data; otherwise they get written to the data files */
         RMsgSndSend(tlist[0], &msg);
 
-        sprintf(logtxt, "SBC: %d  SFC: %d\n", snd_bm_cnt, snd_freq_cnt);
+        sprintf(logtxt, "SBC: %d  SFC: %d", snd_bm_cnt, snd_freq_cnt);
         ErrLog(errlog, progname, logtxt);
 
         /* set the scan variable for the sounding mode data file only */
@@ -518,7 +518,7 @@ int main(int argc,char *argv[]) {
         /* save the sounding mode data */
         write_snd_record(progname, &prm, &fit);
 
-        ErrLog(errlog, progname, "Polling SND for exit.");
+        ErrLog(errlog, progname, "Polling SND for exit.\n");
         exitpoll=RadarShell(sid,&rstable);
         if (exitpoll !=0) break;
 

--- a/qnx4/interleavesound.1.00/interleavesound.c
+++ b/qnx4/interleavesound.1.00/interleavesound.c
@@ -120,6 +120,8 @@ int main(int argc,char *argv[]) {
   int skip;
   int cnt=0;
 
+  int def_nrang=75;
+
   unsigned char discretion=0;
 
   /* ---------- Beam sequence for interleavedscan ---------- */
@@ -176,6 +178,7 @@ int main(int argc,char *argv[]) {
   int odd_beams=0;
   int snd_freq;
   int snd_frqrng=100;
+  int snd_nrang=75;
   float snd_time, snd_intt, time_needed=1.25;
   unsigned char limit_fswitch=0;
 
@@ -239,7 +242,7 @@ int main(int argc,char *argv[]) {
   mplgs  = 23;
   mpinc  = 1500;
   dmpinc = 1500;
-  nrang  = 75;
+  nrang  = def_nrang;
   rsep   = 45;
   txpl   = 300; /* recalculated below with rsep */
   frang  = 180;
@@ -284,6 +287,8 @@ int main(int argc,char *argv[]) {
   OpsLogStart(errlog,progname,argc,argv);
 
   SiteSetupHardware();
+
+  def_nrang = nrang;
 
   // set a negative CPID for discretionary time
   if (discretion) cp = -cp;
@@ -444,6 +449,7 @@ int main(int argc,char *argv[]) {
       while (snd_time-snd_intt > time_needed) {
         intsc = snd_intt_sc;
         intus = snd_intt_us;
+        nrang = snd_nrang;
 
         /* set the beam */
         bmnum = snd_bms[snd_bm_cnt] + odd_beams;
@@ -548,6 +554,7 @@ int main(int argc,char *argv[]) {
       /* now wait for the next interleavescan */
       intsc = fast_intt_sc;
       intus = fast_intt_us;
+      nrang = def_nrang;
       OpsWaitBoundary(scnsc,scnus);
     }
 

--- a/qnx4/interleavesound.1.00/interleavesound.c
+++ b/qnx4/interleavesound.1.00/interleavesound.c
@@ -472,6 +472,8 @@ int main(int argc,char *argv[]) {
         SiteSetBeam(bmnum);
 
         ErrLog(errlog, progname, "Doing SND clear frequency search.");
+        sprintf(logtxt,"FRQ: %d %d",snd_freq,snd_frqrng);
+        ErrLog(errlog,progname,logtxt);
         if (SiteFCLR(snd_freq, snd_freq + snd_frqrng)==FREQ_LOCAL)
           ErrLog(errlog,progname,"Frequency Synthesizer in local mode.");
         SiteSetFreq(tfreq);

--- a/qnx4/interleavesound.1.00/interleavesound.c
+++ b/qnx4/interleavesound.1.00/interleavesound.c
@@ -236,20 +236,20 @@ int main(int argc,char *argv[]) {
                   &dmpinc,&nmpinc,
                   &frqrng,&xcnt);
 
+  SiteStart();
+
   // For 1-min normal scan
   cp     = 197;
   intsc  = fast_intt_sc;
   intus  = fast_intt_us;
   mppul  = 8;
   mplgs  = 23;
-  mpinc  = 1500;
   dmpinc = 1500;
+  nmpinc = 1500;
   nrang  = 75;
   rsep   = 45;
   txpl   = 300; /* recalculated below with rsep */
   frang  = 180;
-
-  SiteStart();
 
 #if 1
   //maxatten=1;	//Chris

--- a/qnx4/interleavesound.1.00/interleavesound.c
+++ b/qnx4/interleavesound.1.00/interleavesound.c
@@ -180,20 +180,22 @@ int main(int argc,char *argv[]) {
   int snd_frqrng=100;
   int snd_nrang=75;
   float snd_time, snd_intt, time_needed=1.25;
+  int snd_bms_tot, snd_intt_sc, snd_intt_us;
+  int fast_intt_sc, fast_intt_us;
   unsigned char limit_fswitch=0;
 
   if (num_scans == 16) {
-    int snd_bms_tot=8;
-    int fast_intt_sc=3;
-    int fast_intt_us=0;
-    int snd_intt_sc=2;
-    int snd_intt_us=0;
+    snd_bms_tot=8;
+    fast_intt_sc=3;
+    fast_intt_us=0;
+    snd_intt_sc=2;
+    snd_intt_us=0;
   } else if (num_scans == 20) {
-    int snd_bms_tot=10;
-    int fast_intt_sc=2;
-    int fast_intt_us=400000;
-    int snd_intt_sc=1;
-    int snd_intt_us=500000;
+    snd_bms_tot=10;
+    fast_intt_sc=2;
+    fast_intt_us=400000;
+    snd_intt_sc=1;
+    snd_intt_us=500000;
   }
 
   snd_intt = snd_intt_sc + snd_intt_us*1e-6;

--- a/qnx4/interleavesound.1.00/interleavesound.c
+++ b/qnx4/interleavesound.1.00/interleavesound.c
@@ -188,7 +188,7 @@ int main(int argc,char *argv[]) {
     int fast_intt_us=0;
     int snd_intt_sc=2;
     int snd_intt_us=0;
-  else if (num_scans == 20) {
+  } else if (num_scans == 20) {
     int snd_bms_tot=10;
     int fast_intt_sc=2;
     int fast_intt_us=400000;

--- a/qnx4/interleavesound.1.00/version.info
+++ b/qnx4/interleavesound.1.00/version.info
@@ -1,9 +1,13 @@
 # $Log: version.info,v $
 #
+# Revision 1.1  2021/09/15 egthomas
+# Modification to set number of ranges used for frequency
+# sounding independently of nrang for the interleaved scan
+#
 # Revision 1.0  2019/06/14 egthomas
 # Initial revision from interleavedscan and normalsound
 #
 #
-interleavesound.c 1.00
+interleavesound.c 1.01
 sndwrite.c 1.01
 sndwrite.h 1.00

--- a/qnx4/interleavesound_stereo.1.00/interleavesound_stereo.c
+++ b/qnx4/interleavesound_stereo.1.00/interleavesound_stereo.c
@@ -1007,6 +1007,8 @@ void write_snd_record(char *progname, struct RadarParm *prm, struct FitData *fit
   status = SndFwrite(out, prm, fit);
   if (status == -1) {
     ErrLog(errlog,progname,"Error writing sounding record.");
+  } else {
+    ErrLog(errlog,progname,"Sounding record succesfully written.");
   }
 
   fclose(out);

--- a/qnx4/normalsound.3.00/normalsound.c
+++ b/qnx4/normalsound.3.00/normalsound.c
@@ -194,21 +194,23 @@ int main(int argc,char *argv[]) {
   int snd_frqrng=100;
   int snd_nrang=75;
   float snd_time, snd_intt, time_needed=1.25;
+  int snd_bms_tot, snd_intt_sc, snd_intt_us;
+  int fast_intt_sc, fast_intt_us;
 
   if (snd_bms_tot == 8) {
-    int normal_intt_sc=6;
-    int normal_intt_us=0;
-    int fast_intt_sc=3;
-    int fast_intt_us=0;
-    int snd_intt_sc=2;
-    int snd_intt_us=0;
-  else if (snd_bms_tot == 10) {
-    int normal_intt_sc=5;
-    int normal_intt_us=0;
-    int fast_intt_sc=2;
-    int fast_intt_us=400000;
-    int snd_intt_sc=1;
-    int snd_intt_us=500000;
+    normal_intt_sc=6;
+    normal_intt_us=0;
+    fast_intt_sc=3;
+    fast_intt_us=0;
+    snd_intt_sc=2;
+    snd_intt_us=0;
+  } else if (snd_bms_tot == 10) {
+    normal_intt_sc=5;
+    normal_intt_us=0;
+    fast_intt_sc=2;
+    fast_intt_us=400000;
+    snd_intt_sc=1;
+    snd_intt_us=500000;
   }
 
   snd_intt = snd_intt_sc + snd_intt_us*1e-6;

--- a/qnx4/normalsound.3.00/normalsound.c
+++ b/qnx4/normalsound.3.00/normalsound.c
@@ -46,8 +46,9 @@
 
 /*
  $Log: normalsound.c,v $
- Revision 3.0  2020/09/25 egthomas
- Modification to use dmap sounding file format
+ Revision 3.0  2021/09/15 egthomas
+ Modification to use dmap sounding file format and
+ independent number of ranges for frequency sounding
 
  Revision 2.7  2008/03/15 00:47:25  code
  Added iqwrite.
@@ -82,7 +83,7 @@
 #define TASK_NAMES "echo_data","iqwrite","rawacfwrite","fitacfwrite"
 
 char cmdlne[1024];
-char progid[80]={"$Id: normalsound.c,v 3.0 2020/09/25 egthomas Exp $"};
+char progid[80]={"$Id: normalsound.c,v 3.0 2021/09/15 egthomas Exp $"};
 char progname[256];
 struct TaskID *errlog;
 
@@ -197,6 +198,7 @@ int main(int argc,char *argv[]) {
   int normal_intt_sc, normal_intt_us;
   int fast_intt_sc, fast_intt_us;
   int snd_intt_sc, snd_intt_us;
+  unsigned char limit_fswitch=0;
 
   if (snd_bms_tot == 8) {
     normal_intt_sc=6;
@@ -291,6 +293,9 @@ int main(int argc,char *argv[]) {
   OptionAdd(&opt, "fast", 'x', &fast);
   OptionAdd(&opt, "frqrng", 'i', &frqrng);
   OptionAdd(&opt, "sfrqrng", 'i',&snd_frqrng); /* sounding FCLR window [kHz] */
+  OptionAdd(&opt, "lf", 'x', &limit_fswitch);  /* limit amount of frequency switching
+                                                  by iterating over all sounding beams
+                                                  before proceeding to next frequency */
 
   arg=OptionProcess(1,argc,argv,&opt,NULL);
 
@@ -538,15 +543,29 @@ int main(int argc,char *argv[]) {
         exitpoll=RadarShell(sid,&rstable);
         if (exitpoll !=0) break;
 
-        /* check for the end of a beam loop */
-        snd_freq_cnt++;
-        if (snd_freq_cnt >= snd_freqs_tot) {
-          /* reset the freq counter and increment the beam counter */
-          snd_freq_cnt = 0;
+        if (limit_fswitch) {
+          /* check for the end of a frequency loop (optional) */
           snd_bm_cnt++;
           if (snd_bm_cnt >= snd_bms_tot) {
+            /* reset the beam counter and increment the freq counter */
             snd_bm_cnt = 0;
             odd_beams = !odd_beams;
+            if (!odd_beams) snd_freq_cnt++;
+            if (snd_freq_cnt >= snd_freqs_tot) {
+              snd_freq_cnt = 0;
+            }
+          }
+        } else {
+          /* check for the end of a beam loop (default) */
+          snd_freq_cnt++;
+          if (snd_freq_cnt >= snd_freqs_tot) {
+            /* reset the freq counter and increment the beam counter */
+            snd_freq_cnt = 0;
+            snd_bm_cnt++;
+            if (snd_bm_cnt >= snd_bms_tot) {
+              snd_bm_cnt = 0;
+              odd_beams = !odd_beams;
+            }
           }
         }
 

--- a/qnx4/normalsound.3.00/normalsound.c
+++ b/qnx4/normalsound.3.00/normalsound.c
@@ -194,7 +194,7 @@ int main(int argc,char *argv[]) {
   int snd_frqrng=100;
   int snd_nrang=75;
   float snd_time, snd_intt, time_needed=1.25;
-  int snd_bms_tot, snd_intt_sc, snd_intt_us;
+  int snd_intt_sc, snd_intt_us;
   int fast_intt_sc, fast_intt_us;
 
   if (snd_bms_tot == 8) {

--- a/qnx4/normalsound.3.00/normalsound.c
+++ b/qnx4/normalsound.3.00/normalsound.c
@@ -480,6 +480,8 @@ int main(int argc,char *argv[]) {
         SiteSetBeam(bmnum);
 
         ErrLog(errlog, progname, "Doing SND clear frequency search.");
+        sprintf(logtxt,"FRQ: %d %d",snd_freq,snd_frqrng);
+        ErrLog(errlog,progname,logtxt);
         if (SiteFCLR(snd_freq, snd_freq + snd_frqrng)==FREQ_LOCAL)
           ErrLog(errlog,progname,"Frequency Synthesizer in local mode.");
         SiteSetFreq(tfreq);

--- a/qnx4/normalsound.3.00/normalsound.c
+++ b/qnx4/normalsound.3.00/normalsound.c
@@ -516,7 +516,7 @@ int main(int argc,char *argv[]) {
         /* Only send these to echo_data; otherwise they get written to the data files */
         RMsgSndSend(tlist[0], &msg);
 
-        sprintf(logtxt, "SBC: %d  SFC: %d\n", snd_bm_cnt, snd_freq_cnt);
+        sprintf(logtxt, "SBC: %d  SFC: %d", snd_bm_cnt, snd_freq_cnt);
         ErrLog(errlog, progname, logtxt);
 
         /* set the scan variable for the sounding mode data file only */
@@ -529,7 +529,7 @@ int main(int argc,char *argv[]) {
         /* save the sounding mode data */
         write_snd_record(progname, &prm, &fit);
 
-        ErrLog(errlog, progname, "Polling SND for exit.");
+        ErrLog(errlog, progname, "Polling SND for exit.\n");
         exitpoll=RadarShell(sid,&rstable);
         if (exitpoll !=0) break;
 

--- a/qnx4/normalsound.3.00/normalsound.c
+++ b/qnx4/normalsound.3.00/normalsound.c
@@ -194,8 +194,9 @@ int main(int argc,char *argv[]) {
   int snd_frqrng=100;
   int snd_nrang=75;
   float snd_time, snd_intt, time_needed=1.25;
-  int snd_intt_sc, snd_intt_us;
+  int normal_intt_sc, normal_intt_us;
   int fast_intt_sc, fast_intt_us;
+  int snd_intt_sc, snd_intt_us;
 
   if (snd_bms_tot == 8) {
     normal_intt_sc=6;

--- a/qnx4/normalsound.3.00/normalsound.c
+++ b/qnx4/normalsound.3.00/normalsound.c
@@ -145,6 +145,8 @@ int main(int argc,char *argv[]) {
   int skip;
   int cnt=0;
 
+  int def_nrang=75;
+
   unsigned char fast=0;
   unsigned char discretion=0;
 
@@ -190,6 +192,7 @@ int main(int argc,char *argv[]) {
   int odd_beams=0;
   int snd_freq;
   int snd_frqrng=100;
+  int snd_nrang=75;
   float snd_time, snd_intt, time_needed=1.25;
 
   if (snd_bms_tot == 8) {
@@ -253,7 +256,7 @@ int main(int argc,char *argv[]) {
   mplgs  = 23;
   mpinc  = 1500;
   dmpinc = 1500;
-  nrang  = 75;
+  nrang  = def_nrang;
   rsep   = 45;
   txpl   = 300; /* recalculated below with rsep */
   frang  = 180;
@@ -305,6 +308,9 @@ int main(int argc,char *argv[]) {
     intsc = fast_intt_sc;
     intus = fast_intt_us;
   }
+
+  def_nrang = nrang;
+
   if (discretion) cp = -cp;
 
   // recalculate txpl
@@ -454,6 +460,7 @@ int main(int argc,char *argv[]) {
       while (snd_time-snd_intt > time_needed) {
         intsc = snd_intt_sc;
         intus = snd_intt_us;
+        nrang = snd_nrang;
 
         /* set the beam */
         bmnum = snd_bms[snd_bm_cnt] + odd_beams;
@@ -549,6 +556,7 @@ int main(int argc,char *argv[]) {
         intsc = normal_intt_sc;
         intus = normal_intt_us;
       }
+      nrang = def_nrang;
       OpsWaitBoundary(scnsc,scnus);
     }
 

--- a/qnx4/normalsound.3.00/normalsound.c
+++ b/qnx4/normalsound.3.00/normalsound.c
@@ -252,19 +252,19 @@ int main(int argc,char *argv[]) {
                   &dmpinc,&nmpinc,
                   &frqrng,&xcnt);
 
+  SiteStart();
+
   cp     = 155;
   intsc  = normal_intt_sc;
   intus  = normal_intt_us;
   mppul  = 8;
   mplgs  = 23;
-  mpinc  = 1500;
   dmpinc = 1500;
+  nmpinc = 1500;
   nrang  = 75;
   rsep   = 45;
   txpl   = 300; /* recalculated below with rsep */
   frang  = 180;
-
-  SiteStart();
 
 #if 1
   //maxatten=1;	//Chris

--- a/qnx4/normalsound.3.00/version.info
+++ b/qnx4/normalsound.3.00/version.info
@@ -1,7 +1,8 @@
 # $Log: version.info,v $
 #
-# Revision 3.0  2020/09/25 egthomas
-# Modification to use dmap sounding file format
+# Revision 3.0  2021/09/15 egthomas
+# Modification to use dmap sounding file format and
+# independent number of ranges for frequency sounding
 #
 #Revision 2.7  2008/03/15 00:47:44  code
 #Added iqwrite.

--- a/qnx6/interleavesound.1.0/interleavesound_cv.c
+++ b/qnx6/interleavesound.1.0/interleavesound_cv.c
@@ -109,7 +109,6 @@ int main(int argc,char *argv[]) {
   char tempLog[40];
 
   int exitpoll=0;
-  int scannowait=0;
 
   int scnsc=60;
   int scnus=0;
@@ -121,7 +120,7 @@ int main(int argc,char *argv[]) {
   int status=0;
   int fixfrq=0;
 
-  int def_nrang=100;
+  int def_nrang=0;
 
   /* new variables for dynamically creating beam sequences */
   int *bms;           /* scanning beams                                     */
@@ -177,7 +176,7 @@ int main(int argc,char *argv[]) {
   mplgs  = 23;
   mpinc  = 1500;
   dmpinc = 1500;
-  nrang  = def_nrang;
+  nrang  = 100;
   rsep   = 45;
   txpl   = 300;     /* note: recomputed below */
   dfrq   = 10200;
@@ -250,9 +249,6 @@ int main(int argc,char *argv[]) {
     fprintf(stderr,"Sounder File: %s not found\n",snd_filename);
   }
 
-  /* end of main Dartmouth mods */
-  /* not sure if -nrang commandline option works */
-
   if ((errlog.sock=TCPIPMsgOpen(errlog.host,errlog.port))==-1) {
     fprintf(stderr,"Error connecting to error log.\n");
   }
@@ -262,14 +258,9 @@ int main(int argc,char *argv[]) {
 
   for (n=0;n<tnum;n++) task[n].port+=baseport;
 
-  /* rst/usr/codebase/superdarn/src.lib/os/ops.1.10/src/setup.c */
   OpsStart(ststr);
 
-  /* rst/usr/codebase/superdarn/src.lib/os/site.1.3/src/build.c */
-  /* note that stid is a global variable set in the previous function...
-      rst/usr/codebase/superdarn/src.lib/os/ops.1.10/src/global.c */
   status=SiteBuild(stid);
-
   if (status==-1) {
     fprintf(stderr,"Could not identify station.\n");
     exit(1);
@@ -292,7 +283,6 @@ int main(int argc,char *argv[]) {
 
   strncpy(combf,progid,80);
 
-  /* rst/usr/codebase/superdarn/src.lib/os/ops.1.10/src */
   OpsSetupCommand(argc,argv);
   OpsSetupShell();
 
@@ -443,7 +433,6 @@ int main(int argc,char *argv[]) {
 
     } while (1);
 
-    ErrLog(errlog.sock,progname,"Waiting for scan boundary.");
 
     if (exitpoll==0) {
       /* In here comes the sounder code */
@@ -453,15 +442,20 @@ int main(int argc,char *argv[]) {
       /* set the xcf variable to do cross-correlations (AOA) */
       xcf = 1;
 
+      /* set the sounding mode integration time and number of ranges */
+      intsc = snd_intt_sc;
+      intus = snd_intt_us;
+      nrang = snd_nrang;
+
+      /* make a new timing sequence for the sounding */
+      tsgid = SiteTimeSeq(ptab);
+
       /* we have time until the end of the minute to do sounding */
       /* minus a safety factor given in time_needed */
       TimeReadClock(&yr,&mo,&dy,&hr,&mt,&sc,&us);
       snd_time = 60.0 - (sc + us*1e-6);
 
       while (snd_time-snd_intt > time_needed) {
-        intsc = snd_intt_sc;
-        intus = snd_intt_us;
-        nrang = snd_nrang;
 
         /* set the beam */
         bmnum = snd_bms[snd_bm_cnt] + odd_beams;
@@ -470,19 +464,19 @@ int main(int argc,char *argv[]) {
         snd_freq = snd_freqs[snd_freq_cnt];
 
         /* the scanning code is here */
-        tsgid = SiteTimeSeq(ptab);
         sprintf(logtxt,"Integrating SND beam:%d intt:%ds.%dus (%d:%d:%d:%d)",bmnum,intsc,intus,hr,mt,sc,us);
         ErrLog(errlog.sock,progname,logtxt);
         ErrLog(errlog.sock,progname,"Setting SND beam.");
         SiteStartIntt(intsc,intus);
+
         ErrLog(errlog.sock, progname, "Doing SND clear frequency search.");
         sprintf(logtxt, "FRQ: %d %d", snd_freq, snd_frqrng);
         ErrLog(errlog.sock,progname, logtxt);
         tfreq = SiteFCLR(snd_freq, snd_freq + snd_frqrng);
-/*
- *           sprintf(logtxt,"Transmitting SND on: %d (Noise=%g)",tfreq,noise);
- *                     ErrLog(errlog.sock, progname, logtxt);
- *                     */
+
+        sprintf(logtxt,"Transmitting SND on: %d (Noise=%g)",tfreq,noise);
+        ErrLog(errlog.sock, progname, logtxt);
+
         nave = SiteIntegrate(lags);
         if (nave < 0) {
           sprintf(logtxt, "SND integration error: %d", nave);
@@ -563,10 +557,13 @@ int main(int argc,char *argv[]) {
       }
 
       /* now wait for the next interleavescan */
+      ErrLog(errlog.sock,progname,"Waiting for scan boundary.");
+
       intsc = fast_intt_sc;
       intus = fast_intt_us;
       nrang = def_nrang;
-      if (scannowait==0) SiteEndScan(scnsc,scnus,5000);
+
+      SiteEndScan(scnsc,scnus,5000);
     }
 
   } while (exitpoll==0);
@@ -651,6 +648,8 @@ void write_snd_record(char *progname, struct RadarParm *prm, struct FitData *fit
   status = SndFwrite(out, prm, fit);
   if (status == -1) {
     ErrLog(errlog.sock,progname,"Error writing sounding record.");
+  } else {
+    ErrLog(errlog.sock,progname,"Sounding record successfully written.");
   }
 
   fclose(out);

--- a/qnx6/interleavesound.1.0/interleavesound_cv.c
+++ b/qnx6/interleavesound.1.0/interleavesound_cv.c
@@ -108,8 +108,6 @@ int main(int argc,char *argv[]) {
   char logtxt[1024]="";
   char tempLog[40];
 
-  int exitpoll=0;
-
   int scnsc=60;
   int scnus=0;
 
@@ -425,7 +423,6 @@ int main(int argc,char *argv[]) {
 
       RadarShell(shell.sock,&rstable);
 
-      if (exitpoll !=0 ) break;
       scan = 0;
       if (skip == (nintgs-1)) break;
       skip++;
@@ -434,139 +431,136 @@ int main(int argc,char *argv[]) {
     } while (1);
 
 
-    if (exitpoll==0) {
-      /* In here comes the sounder code */
-      /* set the "sounder mode" scan variable */
-      scan = -2;
+    /* In here comes the sounder code */
+    /* set the "sounder mode" scan variable */
+    scan = -2;
 
-      /* set the xcf variable to do cross-correlations (AOA) */
-      xcf = 1;
+    /* set the xcf variable to do cross-correlations (AOA) */
+    xcf = 1;
 
-      /* set the sounding mode integration time and number of ranges */
-      intsc = snd_intt_sc;
-      intus = snd_intt_us;
-      nrang = snd_nrang;
+    /* set the sounding mode integration time and number of ranges */
+    intsc = snd_intt_sc;
+    intus = snd_intt_us;
+    nrang = snd_nrang;
 
-      /* make a new timing sequence for the sounding */
-      tsgid = SiteTimeSeq(ptab);
+    /* make a new timing sequence for the sounding */
+    tsgid = SiteTimeSeq(ptab);
 
-      /* we have time until the end of the minute to do sounding */
-      /* minus a safety factor given in time_needed */
-      TimeReadClock(&yr,&mo,&dy,&hr,&mt,&sc,&us);
-      snd_time = 60.0 - (sc + us*1e-6);
+    /* we have time until the end of the minute to do sounding */
+    /* minus a safety factor given in time_needed */
+    TimeReadClock(&yr,&mo,&dy,&hr,&mt,&sc,&us);
+    snd_time = 60.0 - (sc + us*1e-6);
 
-      while (snd_time-snd_intt > time_needed) {
+    while (snd_time-snd_intt > time_needed) {
 
-        /* set the beam */
-        bmnum = snd_bms[snd_bm_cnt] + odd_beams;
+      /* set the beam */
+      bmnum = snd_bms[snd_bm_cnt] + odd_beams;
 
-        /* snd_freq will be an array of frequencies to step through */
-        snd_freq = snd_freqs[snd_freq_cnt];
+      /* snd_freq will be an array of frequencies to step through */
+      snd_freq = snd_freqs[snd_freq_cnt];
 
-        /* the scanning code is here */
-        sprintf(logtxt,"Integrating SND beam:%d intt:%ds.%dus (%d:%d:%d:%d)",bmnum,intsc,intus,hr,mt,sc,us);
-        ErrLog(errlog.sock,progname,logtxt);
-        ErrLog(errlog.sock,progname,"Setting SND beam.");
-        SiteStartIntt(intsc,intus);
+      /* the scanning code is here */
+      sprintf(logtxt,"Integrating SND beam:%d intt:%ds.%dus (%d:%d:%d:%d)",bmnum,intsc,intus,hr,mt,sc,us);
+      ErrLog(errlog.sock,progname,logtxt);
+      ErrLog(errlog.sock,progname,"Setting SND beam.");
+      SiteStartIntt(intsc,intus);
 
-        ErrLog(errlog.sock, progname, "Doing SND clear frequency search.");
-        sprintf(logtxt, "FRQ: %d %d", snd_freq, snd_frqrng);
+      ErrLog(errlog.sock, progname, "Doing SND clear frequency search.");
+      sprintf(logtxt, "FRQ: %d %d", snd_freq, snd_frqrng);
+      ErrLog(errlog.sock,progname, logtxt);
+      tfreq = SiteFCLR(snd_freq, snd_freq + snd_frqrng);
+
+      sprintf(logtxt,"Transmitting SND on: %d (Noise=%g)",tfreq,noise);
+      ErrLog(errlog.sock, progname, logtxt);
+
+      nave = SiteIntegrate(lags);
+      if (nave < 0) {
+        sprintf(logtxt, "SND integration error: %d", nave);
         ErrLog(errlog.sock,progname, logtxt);
-        tfreq = SiteFCLR(snd_freq, snd_freq + snd_frqrng);
+        continue;
+      }
+      sprintf(logtxt,"Number of SND sequences: %d",nave);
+      ErrLog(errlog.sock,progname,logtxt);
 
-        sprintf(logtxt,"Transmitting SND on: %d (Noise=%g)",tfreq,noise);
-        ErrLog(errlog.sock, progname, logtxt);
+      OpsBuildPrm(prm,ptab,lags);
+      OpsBuildIQ(iq,&badtr);
+      OpsBuildRaw(raw);
+      FitACF(prm,raw,fblk,fit);
 
-        nave = SiteIntegrate(lags);
-        if (nave < 0) {
-          sprintf(logtxt, "SND integration error: %d", nave);
-          ErrLog(errlog.sock,progname, logtxt);
-          continue;
-        }
-        sprintf(logtxt,"Number of SND sequences: %d",nave);
-        ErrLog(errlog.sock,progname,logtxt);
+      ErrLog(errlog.sock, progname, "Sending SND messages.");
+      msg.num = 0;
+      msg.tsize = 0;
 
-        OpsBuildPrm(prm,ptab,lags);
-        OpsBuildIQ(iq,&badtr);
-        OpsBuildRaw(raw);
-        FitACF(prm,raw,fblk,fit);
+      tmpbuf=RadarParmFlatten(prm,&tmpsze);
+      RMsgSndAdd(&msg,tmpsze,tmpbuf,PRM_TYPE,0);
 
-        ErrLog(errlog.sock, progname, "Sending SND messages.");
-        msg.num = 0;
-        msg.tsize = 0;
+      tmpbuf=IQFlatten(iq,prm->nave,&tmpsze);
+      RMsgSndAdd(&msg,tmpsze,tmpbuf,IQ_TYPE,0);
 
-        tmpbuf=RadarParmFlatten(prm,&tmpsze);
-        RMsgSndAdd(&msg,tmpsze,tmpbuf,PRM_TYPE,0);
+      RMsgSndAdd(&msg,sizeof(unsigned int)*2*iq->tbadtr,
+             (unsigned char *) badtr,BADTR_TYPE,0);
 
-        tmpbuf=IQFlatten(iq,prm->nave,&tmpsze);
-        RMsgSndAdd(&msg,tmpsze,tmpbuf,IQ_TYPE,0);
+      RMsgSndAdd(&msg,strlen(sharedmemory)+1,
+             (unsigned char *) sharedmemory,IQS_TYPE,0);
 
-        RMsgSndAdd(&msg,sizeof(unsigned int)*2*iq->tbadtr,
-               (unsigned char *) badtr,BADTR_TYPE,0);
+      tmpbuf=RawFlatten(raw,prm->nrang,prm->mplgs,&tmpsze);
+      RMsgSndAdd(&msg,tmpsze,tmpbuf,RAW_TYPE,0);
 
-        RMsgSndAdd(&msg,strlen(sharedmemory)+1,
-               (unsigned char *) sharedmemory,IQS_TYPE,0);
+      tmpbuf=FitFlatten(fit,prm->nrang,&tmpsze);
+      RMsgSndAdd(&msg,tmpsze,tmpbuf,FIT_TYPE,0);
 
-        tmpbuf=RawFlatten(raw,prm->nrang,prm->mplgs,&tmpsze);
-        RMsgSndAdd(&msg,tmpsze,tmpbuf,RAW_TYPE,0);
+      RMsgSndAdd(&msg,strlen(progname)+1,(unsigned char *) progname,NME_TYPE,0);
 
-        tmpbuf=FitFlatten(fit,prm->nrang,&tmpsze);
-        RMsgSndAdd(&msg,tmpsze,tmpbuf,FIT_TYPE,0);
-
-        RMsgSndAdd(&msg,strlen(progname)+1,(unsigned char *) progname,NME_TYPE,0);
-
-        RMsgSndSend(task[RT_TASK].sock,&msg);
-        for (n=0;n<msg.num;n++) {
-          if (msg.data[n].type==PRM_TYPE) free(msg.ptr[n]);
-          if (msg.data[n].type==IQ_TYPE) free(msg.ptr[n]);
-          if (msg.data[n].type==RAW_TYPE) free(msg.ptr[n]);
-          if (msg.data[n].type==FIT_TYPE) free(msg.ptr[n]);
-        }
-
-        sprintf(logtxt, "SBC: %d  SFC: %d", snd_bm_cnt, snd_freq_cnt);
-        ErrLog(errlog.sock, progname, logtxt);
-
-        /* set the scan variable for the sounding mode data file only */
-        if ((bmnum == snd_bms[0]) && (snd_freq == snd_freqs[0])) {
-          prm->scan = 1;
-        } else {
-          prm->scan = 0;
-        }
-
-        /* save the sounding mode data */
-        write_snd_record(progname, prm, fit);
-
-        ErrLog(errlog.sock, progname, "Polling SND for exit.\n");
-        if (exitpoll !=0) break;
-
-        /* check for the end of a beam loop */
-        snd_freq_cnt++;
-        if (snd_freq_cnt >= snd_freqs_tot) {
-          /* reset the freq counter and increment the beam counter */
-          snd_freq_cnt = 0;
-          snd_bm_cnt++;
-          if (snd_bm_cnt >= snd_bms_tot) {
-            snd_bm_cnt = 0;
-            odd_beams = !odd_beams;
-          }
-        }
-
-        /* see if we have enough time for another go round */
-        TimeReadClock(&yr, &mo, &dy, &hr, &mt, &sc, &us);
-        snd_time = 60.0 - (sc + us*1e-6);
+      RMsgSndSend(task[RT_TASK].sock,&msg);
+      for (n=0;n<msg.num;n++) {
+        if (msg.data[n].type==PRM_TYPE) free(msg.ptr[n]);
+        if (msg.data[n].type==IQ_TYPE) free(msg.ptr[n]);
+        if (msg.data[n].type==RAW_TYPE) free(msg.ptr[n]);
+        if (msg.data[n].type==FIT_TYPE) free(msg.ptr[n]);
       }
 
-      /* now wait for the next interleavescan */
-      ErrLog(errlog.sock,progname,"Waiting for scan boundary.");
+      sprintf(logtxt, "SBC: %d  SFC: %d", snd_bm_cnt, snd_freq_cnt);
+      ErrLog(errlog.sock, progname, logtxt);
 
-      intsc = fast_intt_sc;
-      intus = fast_intt_us;
-      nrang = def_nrang;
+      /* set the scan variable for the sounding mode data file only */
+      if ((bmnum == snd_bms[0]) && (snd_freq == snd_freqs[0])) {
+        prm->scan = 1;
+      } else {
+        prm->scan = 0;
+      }
 
-      SiteEndScan(scnsc,scnus,5000);
+      /* save the sounding mode data */
+      write_snd_record(progname, prm, fit);
+
+      ErrLog(errlog.sock, progname, "Polling SND for exit.\n");
+
+      /* check for the end of a beam loop */
+      snd_freq_cnt++;
+      if (snd_freq_cnt >= snd_freqs_tot) {
+        /* reset the freq counter and increment the beam counter */
+        snd_freq_cnt = 0;
+        snd_bm_cnt++;
+        if (snd_bm_cnt >= snd_bms_tot) {
+          snd_bm_cnt = 0;
+          odd_beams = !odd_beams;
+        }
+      }
+
+      /* see if we have enough time for another go round */
+      TimeReadClock(&yr, &mo, &dy, &hr, &mt, &sc, &us);
+      snd_time = 60.0 - (sc + us*1e-6);
     }
 
-  } while (exitpoll==0);
+    /* now wait for the next interleavescan */
+    ErrLog(errlog.sock,progname,"Waiting for scan boundary.");
+
+    intsc = fast_intt_sc;
+    intus = fast_intt_us;
+    nrang = def_nrang;
+
+    SiteEndScan(scnsc,scnus,5000);
+
+  } while (1);
 
   for (n=0;n<tnum;n++) RMsgSndClose(task[n].sock);
 

--- a/qnx6/interleavesound.1.0/interleavesound_cv.c
+++ b/qnx6/interleavesound.1.0/interleavesound_cv.c
@@ -523,7 +523,7 @@ int main(int argc,char *argv[]) {
           if (msg.data[n].type==FIT_TYPE) free(msg.ptr[n]);
         }
 
-        sprintf(logtxt, "SBC: %d  SFC: %d\n", snd_bm_cnt, snd_freq_cnt);
+        sprintf(logtxt, "SBC: %d  SFC: %d", snd_bm_cnt, snd_freq_cnt);
         ErrLog(errlog.sock, progname, logtxt);
 
         /* set the scan variable for the sounding mode data file only */
@@ -536,7 +536,7 @@ int main(int argc,char *argv[]) {
         /* save the sounding mode data */
         write_snd_record(progname, prm, fit);
 
-        ErrLog(errlog.sock, progname, "Polling SND for exit.");
+        ErrLog(errlog.sock, progname, "Polling SND for exit.\n");
         if (exitpoll !=0) break;
 
         /* check for the end of a beam loop */

--- a/qnx6/interleavesound.1.0/interleavesound_cv.c
+++ b/qnx6/interleavesound.1.0/interleavesound_cv.c
@@ -121,6 +121,8 @@ int main(int argc,char *argv[]) {
   int status=0;
   int fixfrq=0;
 
+  int def_nrang=100;
+
   /* new variables for dynamically creating beam sequences */
   int *bms;           /* scanning beams                                     */
   int intgt[20];      /* start times of each integration period             */
@@ -153,6 +155,7 @@ int main(int argc,char *argv[]) {
   int snd_bms_tot=10, odd_beams=0;
   int snd_freq;
   int snd_frqrng=100;
+  int snd_nrang=75;
   int fast_intt_sc=2;
   int fast_intt_us=500000;
   int snd_intt_sc=1;
@@ -174,7 +177,7 @@ int main(int argc,char *argv[]) {
   mplgs  = 23;
   mpinc  = 1500;
   dmpinc = 1500;
-  nrang  = 100;
+  nrang  = def_nrang;
   rsep   = 45;
   txpl   = 300;     /* note: recomputed below */
   dfrq   = 10200;
@@ -306,6 +309,8 @@ int main(int argc,char *argv[]) {
     exit (1);
   }
 
+  def_nrang = nrang;
+
   if (discretion) cp = -cp;
 
   txpl=(rsep*20)/3;     /* computing TX pulse length */
@@ -320,9 +325,9 @@ int main(int argc,char *argv[]) {
 
   OpsFitACFStart();
 
-  tsgid=SiteTimeSeq(ptab);  /* get the timing sequence */
-
   do {
+
+    tsgid=SiteTimeSeq(ptab);  /* get the timing sequence */
 
     if (SiteStartScan() !=0) continue;
 
@@ -456,6 +461,7 @@ int main(int argc,char *argv[]) {
       while (snd_time-snd_intt > time_needed) {
         intsc = snd_intt_sc;
         intus = snd_intt_us;
+        nrang = snd_nrang;
 
         /* set the beam */
         bmnum = snd_bms[snd_bm_cnt] + odd_beams;
@@ -464,6 +470,7 @@ int main(int argc,char *argv[]) {
         snd_freq = snd_freqs[snd_freq_cnt];
 
         /* the scanning code is here */
+        tsgid = SiteTimeSeq(ptab);
         sprintf(logtxt,"Integrating SND beam:%d intt:%ds.%dus (%d:%d:%d:%d)",bmnum,intsc,intus,hr,mt,sc,us);
         ErrLog(errlog.sock,progname,logtxt);
         ErrLog(errlog.sock,progname,"Setting SND beam.");
@@ -476,7 +483,6 @@ int main(int argc,char *argv[]) {
  *           sprintf(logtxt,"Transmitting SND on: %d (Noise=%g)",tfreq,noise);
  *                     ErrLog(errlog.sock, progname, logtxt);
  *                     */
-        tsgid = SiteTimeSeq(ptab);
         nave = SiteIntegrate(lags);
         if (nave < 0) {
           sprintf(logtxt, "SND integration error: %d", nave);
@@ -559,6 +565,7 @@ int main(int argc,char *argv[]) {
       /* now wait for the next interleavescan */
       intsc = fast_intt_sc;
       intus = fast_intt_us;
+      nrang = def_nrang;
       if (scannowait==0) SiteEndScan(scnsc,scnus,5000);
     }
 

--- a/qnx6/interleavesound.1.0/interleavesound_fh.c
+++ b/qnx6/interleavesound.1.0/interleavesound_fh.c
@@ -538,7 +538,7 @@ int main(int argc,char *argv[]) {
           if (msg.data[n].type==FIT_TYPE) free(msg.ptr[n]);
         }
 
-        sprintf(logtxt, "SBC: %d  SFC: %d\n", snd_bm_cnt, snd_freq_cnt);
+        sprintf(logtxt, "SBC: %d  SFC: %d", snd_bm_cnt, snd_freq_cnt);
         ErrLog(errlog.sock, progname, logtxt);
 
         /* set the scan variable for the sounding mode data file only */
@@ -551,7 +551,7 @@ int main(int argc,char *argv[]) {
         /* save the sounding mode data */
         write_snd_record(progname, prm, fit);
 
-        ErrLog(errlog.sock, progname, "Polling SND for exit.");
+        ErrLog(errlog.sock, progname, "Polling SND for exit.\n");
         if (exitpoll !=0) break;
 
         /* check for the end of a beam loop */

--- a/qnx6/interleavesound.1.0/interleavesound_fh.c
+++ b/qnx6/interleavesound.1.0/interleavesound_fh.c
@@ -128,6 +128,8 @@ int main(int argc,char *argv[]) {
   int status=0;
   int fixfrq=0;
 
+  int def_nrang=100;
+
   /* new variables for dynamically creating beam sequences */
   int *bms;           /* scanning beams                                     */
   int intgt[20];      /* start times of each integration period             */
@@ -160,6 +162,7 @@ int main(int argc,char *argv[]) {
   int snd_bms_tot=10, odd_beams=0;
   int snd_freq;
   int snd_frqrng=100;
+  int snd_nrang=75;
   int fast_intt_sc=2;
   int fast_intt_us=500000;
   int snd_intt_sc=1;
@@ -181,7 +184,7 @@ int main(int argc,char *argv[]) {
   mplgs  = 23;
   mpinc  = 1500;
   dmpinc = 1500;
-  nrang  = 100;
+  nrang  = def_nrang;
   rsep   = 45;
   txpl   = 300;     /* note: recomputed below */
   dfrq   = 10200;
@@ -324,6 +327,8 @@ int main(int argc,char *argv[]) {
     exit (1);
   }
 
+  def_nrang = nrang;
+
   if (discretion) cp = -cp;
 
   txpl=(rsep*20)/3;     /* computing TX pulse length */
@@ -338,9 +343,9 @@ int main(int argc,char *argv[]) {
 
   OpsFitACFStart();
 
-  tsgid=SiteTimeSeq(ptab);  /* get the timing sequence */
-
   do {
+
+    tsgid=SiteTimeSeq(ptab);  /* get the timing sequence */
 
     if (SiteStartScan() !=0) continue;
 
@@ -474,6 +479,7 @@ int main(int argc,char *argv[]) {
       while (snd_time-snd_intt > time_needed) {
         intsc = snd_intt_sc;
         intus = snd_intt_us;
+        nrang = snd_nrang;
 
         /* set the beam */
         bmnum = snd_bms[snd_bm_cnt] + odd_beams;
@@ -482,6 +488,7 @@ int main(int argc,char *argv[]) {
         snd_freq = snd_freqs[snd_freq_cnt];
 
         /* the scanning code is here */
+        tsgid = SiteTimeSeq(ptab);
         sprintf(logtxt,"Integrating SND beam:%d intt:%ds.%dus (%d:%d:%d:%d)",bmnum,intsc,intus,hr,mt,sc,us);
         ErrLog(errlog.sock,progname,logtxt);
         ErrLog(errlog.sock,progname,"Setting SND beam.");
@@ -494,7 +501,6 @@ int main(int argc,char *argv[]) {
  *           sprintf(logtxt,"Transmitting SND on: %d (Noise=%g)",tfreq,noise);
  *                     ErrLog(errlog.sock, progname, logtxt);
  *                     */
-        tsgid = SiteTimeSeq(ptab);
         nave = SiteIntegrate(lags);
         if (nave < 0) {
           sprintf(logtxt, "SND integration error: %d", nave);
@@ -577,6 +583,7 @@ int main(int argc,char *argv[]) {
       /* now wait for the next interleavescan */
       intsc = fast_intt_sc;
       intus = fast_intt_us;
+      nrang = def_nrang;
       if (scannowait==0) SiteEndScan(scnsc,scnus);
     }
 

--- a/qnx6/interleavesound.1.0/interleavesound_fh.c
+++ b/qnx6/interleavesound.1.0/interleavesound_fh.c
@@ -115,8 +115,6 @@ int main(int argc,char *argv[]) {
   char logtxt[1024]="";
   char tempLog[40];
 
-  int exitpoll=0;
-
   int scnsc=60;
   int scnus=0;
 
@@ -440,7 +438,6 @@ int main(int argc,char *argv[]) {
 
       RadarShell(shell.sock,&rstable);
 
-      if (exitpoll !=0 ) break;
       scan = 0;
       if (skip == (nintgs-1)) break;
       skip++;
@@ -449,139 +446,136 @@ int main(int argc,char *argv[]) {
     } while (1);
 
 
-    if (exitpoll==0) {
-      /* In here comes the sounder code */
-      /* set the "sounder mode" scan variable */
-      scan = -2;
+    /* In here comes the sounder code */
+    /* set the "sounder mode" scan variable */
+    scan = -2;
 
-      /* set the xcf variable to do cross-correlations (AOA) */
-      xcf = 1;
+    /* set the xcf variable to do cross-correlations (AOA) */
+    xcf = 1;
 
-      /* set the sounding mode integration time and number of ranges */
-      intsc = snd_intt_sc;
-      intus = snd_intt_us;
-      nrang = snd_nrang;
+    /* set the sounding mode integration time and number of ranges */
+    intsc = snd_intt_sc;
+    intus = snd_intt_us;
+    nrang = snd_nrang;
 
-      /* make a new timing sequence for the sounding */
-      tsgid = SiteTimeSeq(ptab);
+    /* make a new timing sequence for the sounding */
+    tsgid = SiteTimeSeq(ptab);
 
-      /* we have time until the end of the minute to do sounding */
-      /* minus a safety factor given in time_needed */
-      TimeReadClock(&yr,&mo,&dy,&hr,&mt,&sc,&us);
-      snd_time = 60.0 - (sc + us*1e-6);
+    /* we have time until the end of the minute to do sounding */
+    /* minus a safety factor given in time_needed */
+    TimeReadClock(&yr,&mo,&dy,&hr,&mt,&sc,&us);
+    snd_time = 60.0 - (sc + us*1e-6);
 
-      while (snd_time-snd_intt > time_needed) {
+    while (snd_time-snd_intt > time_needed) {
 
-        /* set the beam */
-        bmnum = snd_bms[snd_bm_cnt] + odd_beams;
+      /* set the beam */
+      bmnum = snd_bms[snd_bm_cnt] + odd_beams;
 
-        /* snd_freq will be an array of frequencies to step through */
-        snd_freq = snd_freqs[snd_freq_cnt];
+      /* snd_freq will be an array of frequencies to step through */
+      snd_freq = snd_freqs[snd_freq_cnt];
 
-        /* the scanning code is here */
-        sprintf(logtxt,"Integrating SND beam:%d intt:%ds.%dus (%d:%d:%d:%d)",bmnum,intsc,intus,hr,mt,sc,us);
-        ErrLog(errlog.sock,progname,logtxt);
-        ErrLog(errlog.sock,progname,"Setting SND beam.");
-        SiteStartIntt(intsc,intus);
+      /* the scanning code is here */
+      sprintf(logtxt,"Integrating SND beam:%d intt:%ds.%dus (%d:%d:%d:%d)",bmnum,intsc,intus,hr,mt,sc,us);
+      ErrLog(errlog.sock,progname,logtxt);
+      ErrLog(errlog.sock,progname,"Setting SND beam.");
+      SiteStartIntt(intsc,intus);
 
-        ErrLog(errlog.sock, progname, "Doing SND clear frequency search.");
-        sprintf(logtxt, "FRQ: %d %d", snd_freq, snd_frqrng);
+      ErrLog(errlog.sock, progname, "Doing SND clear frequency search.");
+      sprintf(logtxt, "FRQ: %d %d", snd_freq, snd_frqrng);
+      ErrLog(errlog.sock,progname, logtxt);
+      tfreq = SiteFCLR(snd_freq, snd_freq + snd_frqrng);
+
+      sprintf(logtxt,"Transmitting SND on: %d (Noise=%g)",tfreq,noise);
+      ErrLog(errlog.sock, progname, logtxt);
+
+      nave = SiteIntegrate(lags);
+      if (nave < 0) {
+        sprintf(logtxt, "SND integration error: %d", nave);
         ErrLog(errlog.sock,progname, logtxt);
-        tfreq = SiteFCLR(snd_freq, snd_freq + snd_frqrng);
+        continue;
+      }
+      sprintf(logtxt,"Number of SND sequences: %d",nave);
+      ErrLog(errlog.sock,progname,logtxt);
 
-        sprintf(logtxt,"Transmitting SND on: %d (Noise=%g)",tfreq,noise);
-        ErrLog(errlog.sock, progname, logtxt);
+      OpsBuildPrm(prm,ptab,lags);
+      OpsBuildIQ(iq,&badtr);
+      OpsBuildRaw(raw);
+      FitACF(prm,raw,fblk,fit);
 
-        nave = SiteIntegrate(lags);
-        if (nave < 0) {
-          sprintf(logtxt, "SND integration error: %d", nave);
-          ErrLog(errlog.sock,progname, logtxt);
-          continue;
-        }
-        sprintf(logtxt,"Number of SND sequences: %d",nave);
-        ErrLog(errlog.sock,progname,logtxt);
+      ErrLog(errlog.sock, progname, "Sending SND messages.");
+      msg.num = 0;
+      msg.tsize = 0;
 
-        OpsBuildPrm(prm,ptab,lags);
-        OpsBuildIQ(iq,&badtr);
-        OpsBuildRaw(raw);
-        FitACF(prm,raw,fblk,fit);
+      tmpbuf=RadarParmFlatten(prm,&tmpsze);
+      RMsgSndAdd(&msg,tmpsze,tmpbuf,PRM_TYPE,0);
 
-        ErrLog(errlog.sock, progname, "Sending SND messages.");
-        msg.num = 0;
-        msg.tsize = 0;
+      tmpbuf=IQFlatten(iq,prm->nave,&tmpsze);
+      RMsgSndAdd(&msg,tmpsze,tmpbuf,IQ_TYPE,0);
 
-        tmpbuf=RadarParmFlatten(prm,&tmpsze);
-        RMsgSndAdd(&msg,tmpsze,tmpbuf,PRM_TYPE,0);
+      RMsgSndAdd(&msg,sizeof(unsigned int)*2*iq->tbadtr,
+             (unsigned char *) badtr,BADTR_TYPE,0);
 
-        tmpbuf=IQFlatten(iq,prm->nave,&tmpsze);
-        RMsgSndAdd(&msg,tmpsze,tmpbuf,IQ_TYPE,0);
+      RMsgSndAdd(&msg,strlen(sharedmemory)+1,
+             (unsigned char *) sharedmemory,IQS_TYPE,0);
 
-        RMsgSndAdd(&msg,sizeof(unsigned int)*2*iq->tbadtr,
-               (unsigned char *) badtr,BADTR_TYPE,0);
+      tmpbuf=RawFlatten(raw,prm->nrang,prm->mplgs,&tmpsze);
+      RMsgSndAdd(&msg,tmpsze,tmpbuf,RAW_TYPE,0);
 
-        RMsgSndAdd(&msg,strlen(sharedmemory)+1,
-               (unsigned char *) sharedmemory,IQS_TYPE,0);
+      tmpbuf=FitFlatten(fit,prm->nrang,&tmpsze);
+      RMsgSndAdd(&msg,tmpsze,tmpbuf,FIT_TYPE,0);
 
-        tmpbuf=RawFlatten(raw,prm->nrang,prm->mplgs,&tmpsze);
-        RMsgSndAdd(&msg,tmpsze,tmpbuf,RAW_TYPE,0);
+      RMsgSndAdd(&msg,strlen(progname)+1,(unsigned char *) progname,NME_TYPE,0);
 
-        tmpbuf=FitFlatten(fit,prm->nrang,&tmpsze);
-        RMsgSndAdd(&msg,tmpsze,tmpbuf,FIT_TYPE,0);
-
-        RMsgSndAdd(&msg,strlen(progname)+1,(unsigned char *) progname,NME_TYPE,0);
-
-        RMsgSndSend(task[RT_TASK].sock,&msg);
-        for (n=0;n<msg.num;n++) {
-          if (msg.data[n].type==PRM_TYPE) free(msg.ptr[n]);
-          if (msg.data[n].type==IQ_TYPE) free(msg.ptr[n]);
-          if (msg.data[n].type==RAW_TYPE) free(msg.ptr[n]);
-          if (msg.data[n].type==FIT_TYPE) free(msg.ptr[n]);
-        }
-
-        sprintf(logtxt, "SBC: %d  SFC: %d", snd_bm_cnt, snd_freq_cnt);
-        ErrLog(errlog.sock, progname, logtxt);
-
-        /* set the scan variable for the sounding mode data file only */
-        if ((bmnum == snd_bms[0]) && (snd_freq == snd_freqs[0])) {
-          prm->scan = 1;
-        } else {
-          prm->scan = 0;
-        }
-
-        /* save the sounding mode data */
-        write_snd_record(progname, prm, fit);
-
-        ErrLog(errlog.sock, progname, "Polling SND for exit.\n");
-        if (exitpoll !=0) break;
-
-        /* check for the end of a beam loop */
-        snd_freq_cnt++;
-        if (snd_freq_cnt >= snd_freqs_tot) {
-          /* reset the freq counter and increment the beam counter */
-          snd_freq_cnt = 0;
-          snd_bm_cnt++;
-          if (snd_bm_cnt >= snd_bms_tot) {
-            snd_bm_cnt = 0;
-            odd_beams = !odd_beams;
-          }
-        }
-
-        /* see if we have enough time for another go round */
-        TimeReadClock(&yr, &mo, &dy, &hr, &mt, &sc, &us);
-        snd_time = 60.0 - (sc + us*1e-6);
+      RMsgSndSend(task[RT_TASK].sock,&msg);
+      for (n=0;n<msg.num;n++) {
+        if (msg.data[n].type==PRM_TYPE) free(msg.ptr[n]);
+        if (msg.data[n].type==IQ_TYPE) free(msg.ptr[n]);
+        if (msg.data[n].type==RAW_TYPE) free(msg.ptr[n]);
+        if (msg.data[n].type==FIT_TYPE) free(msg.ptr[n]);
       }
 
-      /* now wait for the next interleavescan */
-      ErrLog(errlog.sock,progname,"Waiting for scan boundary.");
+      sprintf(logtxt, "SBC: %d  SFC: %d", snd_bm_cnt, snd_freq_cnt);
+      ErrLog(errlog.sock, progname, logtxt);
 
-      intsc = fast_intt_sc;
-      intus = fast_intt_us;
-      nrang = def_nrang;
+      /* set the scan variable for the sounding mode data file only */
+      if ((bmnum == snd_bms[0]) && (snd_freq == snd_freqs[0])) {
+        prm->scan = 1;
+      } else {
+        prm->scan = 0;
+      }
 
-      SiteEndScan(scnsc,scnus);
+      /* save the sounding mode data */
+      write_snd_record(progname, prm, fit);
+
+      ErrLog(errlog.sock, progname, "Polling SND for exit.\n");
+
+      /* check for the end of a beam loop */
+      snd_freq_cnt++;
+      if (snd_freq_cnt >= snd_freqs_tot) {
+        /* reset the freq counter and increment the beam counter */
+        snd_freq_cnt = 0;
+        snd_bm_cnt++;
+        if (snd_bm_cnt >= snd_bms_tot) {
+          snd_bm_cnt = 0;
+          odd_beams = !odd_beams;
+        }
+      }
+
+      /* see if we have enough time for another go round */
+      TimeReadClock(&yr, &mo, &dy, &hr, &mt, &sc, &us);
+      snd_time = 60.0 - (sc + us*1e-6);
     }
 
-  } while (exitpoll==0);
+    /* now wait for the next interleavescan */
+    ErrLog(errlog.sock,progname,"Waiting for scan boundary.");
+
+    intsc = fast_intt_sc;
+    intus = fast_intt_us;
+    nrang = def_nrang;
+
+    SiteEndScan(scnsc,scnus);
+
+  } while (1);
 
   for (n=0;n<tnum;n++) RMsgSndClose(task[n].sock);
 

--- a/qnx6/normalsound.2.0/normalsound_cv.c
+++ b/qnx6/normalsound.2.0/normalsound_cv.c
@@ -463,10 +463,6 @@ int main(int argc,char *argv[])
       for (n=0;n<tnum;n++) RMsgSndSend(task[n].sock,&msg);
 
       for (n=0; n<msg.num; n++) {
-        //if (msg.data[n].type == PRM_TYPE) free(msg.ptr[n]);
-        //if (msg.data[n].type == IQ_TYPE) free(msg.ptr[n]);
-        //if (msg.data[n].type == RAW_TYPE) free(msg.ptr[n]);
-        //if (msg.data[n].type == FIT_TYPE) free(msg.ptr[n]);
         if ( (msg.data[n].type == PRM_TYPE) ||
              (msg.data[n].type == IQ_TYPE)  ||
              (msg.data[n].type == RAW_TYPE) ||

--- a/qnx6/normalsound.2.0/normalsound_cv.c
+++ b/qnx6/normalsound.2.0/normalsound_cv.c
@@ -141,19 +141,19 @@ int main(int argc,char *argv[])
   unsigned char hlp=0;
 
   if (debug) {
-    printf("Size of int %ld\n",sizeof(int));
-    printf("Size of long %ld\n",sizeof(long));
-    printf("Size of long long %ld\n",sizeof(long long));
-    printf("Size of struct TRTimes %ld\n",sizeof(struct TRTimes));
-    printf("Size of struct SeqPRM %ld\n",sizeof(struct SeqPRM));
-    printf("Size of struct RosData %ld\n",sizeof(struct RosData));
-    printf("Size of struct DataPRM %ld\n",sizeof(struct DataPRM));
-    printf("Size of Struct ControlPRM  %ld\n",sizeof(struct ControlPRM));
-    printf("Size of Struct RadarPRM  %ld\n",sizeof(struct RadarPRM));
-    printf("Size of Struct ROSMsg  %ld\n",sizeof(struct ROSMsg));
-    printf("Size of Struct CLRFreq  %ld\n",sizeof(struct CLRFreqPRM));
-    printf("Size of Struct TSGprm  %ld\n",sizeof(struct TSGprm));
-    printf("Size of Struct SiteSettings  %ld\n",sizeof(struct SiteSettings));
+    printf("Size of int %u\n",sizeof(int));
+    printf("Size of long %u\n",sizeof(long));
+    printf("Size of long long %u\n",sizeof(long long));
+    printf("Size of struct TRTimes %u\n",sizeof(struct TRTimes));
+    printf("Size of struct SeqPRM %u\n",sizeof(struct SeqPRM));
+    printf("Size of struct RosData %u\n",sizeof(struct RosData));
+    printf("Size of struct DataPRM %u\n",sizeof(struct DataPRM));
+    printf("Size of Struct ControlPRM  %u\n",sizeof(struct ControlPRM));
+    printf("Size of Struct RadarPRM  %u\n",sizeof(struct RadarPRM));
+    printf("Size of Struct ROSMsg  %u\n",sizeof(struct ROSMsg));
+    printf("Size of Struct CLRFreq  %u\n",sizeof(struct CLRFreqPRM));
+    printf("Size of Struct TSGprm  %u\n",sizeof(struct TSGprm));
+    printf("Size of Struct SiteSettings  %u\n",sizeof(struct SiteSettings));
   }
 
 
@@ -353,8 +353,6 @@ int main(int argc,char *argv[])
   printf("Entering Scan loop Station ID: %s  %d\n",ststr,stid);
   do {
 
-//    if (timed) gettimeofday(&t0,NULL);
-
     printf("Preparing SiteTimeSeq Station ID: %s  %d\n",ststr,stid);
     tsgid=SiteTimeSeq(ptab);
 
@@ -392,8 +390,6 @@ int main(int argc,char *argv[])
 
     do {
 
-//      if (timed) gettimeofday(&t1,NULL);
-
       TimeReadClock(&yr,&mo,&dy,&hr,&mt,&sc,&us);
 
       if (OpsDayNight()==1) {
@@ -425,7 +421,6 @@ int main(int argc,char *argv[])
       sprintf(logtxt,"Transmitting on: %d (Noise=%g)",tfreq,noise);
       ErrLog(errlog.sock,progname,logtxt);
 
-//      if (timed) gettimeofday(&t2,NULL);
       nave=SiteIntegrate(lags);
       if (nave < 0) {
         sprintf(logtxt,"Integration error:%d",nave);

--- a/qnx6/normalsound.2.0/normalsound_cv.c
+++ b/qnx6/normalsound.2.0/normalsound_cv.c
@@ -570,7 +570,7 @@ int main(int argc,char *argv[])
           if (msg.data[n].type==FIT_TYPE) free(msg.ptr[n]);
         }
 
-        sprintf(logtxt, "SBC: %d  SFC: %d\n", snd_bm_cnt, snd_freq_cnt);
+        sprintf(logtxt, "SBC: %d  SFC: %d", snd_bm_cnt, snd_freq_cnt);
         ErrLog(errlog.sock, progname, logtxt);
 
         /* set the scan variable for the sounding mode data file only */
@@ -583,7 +583,7 @@ int main(int argc,char *argv[])
         /* save the sounding mode data */
         write_snd_record(progname, prm, fit);
 
-        ErrLog(errlog.sock, progname, "Polling SND for exit.");
+        ErrLog(errlog.sock, progname, "Polling SND for exit.\n");
         if (exitpoll !=0) break;
 
         /* check for the end of a beam loop */

--- a/qnx6/normalsound.2.0/normalsound_cv.c
+++ b/qnx6/normalsound.2.0/normalsound_cv.c
@@ -135,6 +135,7 @@ int main(int argc,char *argv[])
   int total_integration_usecs=0;
   int def_intt_sc=0;
   int def_intt_us=0;
+  int def_nrang=0;
   int debug=0;
 
   unsigned char hlp=0;
@@ -170,6 +171,7 @@ int main(int argc,char *argv[])
   int snd_bms_tot=10, odd_beams=0;
   int snd_freq;
   int snd_frqrng=100;
+  int snd_nrang=75;
   int snd_sc=12;
   int snd_intt_sc=1;
   int snd_intt_us=500000;
@@ -325,6 +327,8 @@ int main(int argc,char *argv[])
   def_intt_sc = total_integration_usecs/1E6;
   def_intt_us = total_integration_usecs - (intsc*1e6);
 
+  def_nrang = nrang;
+
   intsc = def_intt_sc;
   intus = def_intt_us;
 
@@ -346,13 +350,13 @@ int main(int argc,char *argv[])
   printf("Preparing OpsFitACFStart Station ID: %s  %d\n",ststr,stid);
   OpsFitACFStart();
 
-  printf("Preparing SiteTimeSeq Station ID: %s  %d\n",ststr,stid);
-  tsgid=SiteTimeSeq(ptab);
-
   printf("Entering Scan loop Station ID: %s  %d\n",ststr,stid);
   do {
 
 //    if (timed) gettimeofday(&t0,NULL);
+
+    printf("Preparing SiteTimeSeq Station ID: %s  %d\n",ststr,stid);
+    tsgid=SiteTimeSeq(ptab);
 
     printf("Entering Site Start Scan Station ID: %s  %d\n",ststr,stid);
     if (SiteStartScan() !=0) continue;
@@ -504,6 +508,7 @@ int main(int argc,char *argv[])
       while (snd_time-snd_intt > time_needed) {
         intsc = snd_intt_sc;
         intus = snd_intt_us;
+        nrang = snd_nrang;
 
         /* set the beam */
         bmnum = snd_bms[snd_bm_cnt] + odd_beams;
@@ -512,6 +517,7 @@ int main(int argc,char *argv[])
         snd_freq = snd_freqs[snd_freq_cnt];
 
         /* the scanning code is here */
+        tsgid = SiteTimeSeq(ptab);
         sprintf(logtxt,"Integrating SND beam:%d intt:%ds.%dus (%d:%d:%d:%d)",bmnum,intsc,intus,hr,mt,sc,us);
         ErrLog(errlog.sock,progname,logtxt);
         ErrLog(errlog.sock,progname,"Setting SND beam.");
@@ -524,7 +530,6 @@ int main(int argc,char *argv[])
  *           sprintf(logtxt,"Transmitting SND on: %d (Noise=%g)",tfreq,noise);
  *                     ErrLog(errlog.sock, progname, logtxt);
  *                     */
-        tsgid = SiteTimeSeq(ptab);
         nave = SiteIntegrate(lags);
         if (nave < 0) {
           sprintf(logtxt, "SND integration error: %d", nave);
@@ -607,6 +612,7 @@ int main(int argc,char *argv[])
       /* now wait for the next normalscan */
       intsc = def_intt_sc;
       intus = def_intt_us;
+      nrang = def_nrang;
       if (scannowait==0) SiteEndScan(scnsc,scnus,5000);
     }
 

--- a/qnx6/normalsound.2.0/normalsound_fh.c
+++ b/qnx6/normalsound.2.0/normalsound_fh.c
@@ -138,6 +138,7 @@ int main(int argc,char *argv[])
   int total_integration_usecs=0;
   int def_intt_sc=0;
   int def_intt_us=0;
+  int def_nrang=0;
   int debug=0;
 
   unsigned char hlp=0;
@@ -173,6 +174,7 @@ int main(int argc,char *argv[])
   int snd_bms_tot=10, odd_beams=0;
   int snd_freq;
   int snd_frqrng=100;
+  int snd_nrang=75;
   int snd_sc=12;
   int snd_intt_sc=1;
   int snd_intt_us=500000;
@@ -336,6 +338,8 @@ int main(int argc,char *argv[])
   def_intt_sc = total_integration_usecs/1E6;
   def_intt_us = total_integration_usecs - (intsc*1e6);
 
+  def_nrang = nrang;
+
   intsc = def_intt_sc;
   intus = def_intt_us;
 
@@ -357,13 +361,13 @@ int main(int argc,char *argv[])
   printf("Preparing OpsFitACFStart Station ID: %s  %d\n",ststr,stid);
   OpsFitACFStart();
 
-  printf("Preparing SiteTimeSeq Station ID: %s  %d\n",ststr,stid);
-  tsgid=SiteTimeSeq(ptab);
-
   printf("Entering Scan loop Station ID: %s  %d\n",ststr,stid);
   do {
 
 //    if (timed) gettimeofday(&t0,NULL);
+
+    printf("Preparing SiteTimeSeq Station ID: %s  %d\n",ststr,stid);
+    tsgid=SiteTimeSeq(ptab);
 
     printf("Entering Site Start Scan Station ID: %s  %d\n",ststr,stid);
     if (SiteStartScan() !=0) continue;
@@ -515,6 +519,7 @@ int main(int argc,char *argv[])
       while (snd_time-snd_intt > time_needed) {
         intsc = snd_intt_sc;
         intus = snd_intt_us;
+        nrang = snd_nrang;
 
         /* set the beam */
         bmnum = snd_bms[snd_bm_cnt] + odd_beams;
@@ -523,6 +528,7 @@ int main(int argc,char *argv[])
         snd_freq = snd_freqs[snd_freq_cnt];
 
         /* the scanning code is here */
+        tsgid = SiteTimeSeq(ptab);
         sprintf(logtxt,"Integrating SND beam:%d intt:%ds.%dus (%d:%d:%d:%d)",bmnum,intsc,intus,hr,mt,sc,us);
         ErrLog(errlog.sock,progname,logtxt);
         ErrLog(errlog.sock,progname,"Setting SND beam.");
@@ -535,7 +541,6 @@ int main(int argc,char *argv[])
  *           sprintf(logtxt,"Transmitting SND on: %d (Noise=%g)",tfreq,noise);
  *                     ErrLog(errlog.sock, progname, logtxt);
  *                     */
-        tsgid = SiteTimeSeq(ptab);
         nave = SiteIntegrate(lags);
         if (nave < 0) {
           sprintf(logtxt, "SND integration error: %d", nave);
@@ -618,6 +623,7 @@ int main(int argc,char *argv[])
       /* now wait for the next normalscan */
       intsc = def_intt_sc;
       intus = def_intt_us;
+      nrang = def_nrang;
       if (scannowait==0) SiteEndScan(scnsc,scnus);
     }
 

--- a/qnx6/normalsound.2.0/normalsound_fh.c
+++ b/qnx6/normalsound.2.0/normalsound_fh.c
@@ -118,8 +118,6 @@ int main(int argc,char *argv[])
 
   char logtxt[1024];
 
-  int exitpoll=0;
- 
   int scnsc=120;    /* total scan period in seconds */
   int scnus=0;
   int skip;
@@ -480,8 +478,6 @@ int main(int argc,char *argv[])
 
       RadarShell(shell.sock,&rstable);
 
-      if (exitpoll != 0) break;
-
       scan = 0;
       if (bmnum == ebm) break;
 
@@ -491,139 +487,136 @@ int main(int argc,char *argv[])
     } while (1);
 
 
-    if (exitpoll==0) {
-      /* In here comes the sounder code */
-      /* set the "sounder mode" scan variable */
-      scan = -2;
+    /* In here comes the sounder code */
+    /* set the "sounder mode" scan variable */
+    scan = -2;
 
-      /* set the xcf variable to do cross-correlations (AOA) */
-      xcf = 1;
+    /* set the xcf variable to do cross-correlations (AOA) */
+    xcf = 1;
 
-      /* set the sounding mode integration time and number of ranges */
-      intsc = snd_intt_sc;
-      intus = snd_intt_us;
-      nrang = snd_nrang;
+    /* set the sounding mode integration time and number of ranges */
+    intsc = snd_intt_sc;
+    intus = snd_intt_us;
+    nrang = snd_nrang;
 
-      /* make a new timing sequence for the sounding */
-      tsgid = SiteTimeSeq(ptab);
+    /* make a new timing sequence for the sounding */
+    tsgid = SiteTimeSeq(ptab);
 
-      /* we have time until the end of the minute to do sounding */
-      /* minus a safety factor given in time_needed */
-      TimeReadClock(&yr,&mo,&dy,&hr,&mt,&sc,&us);
-      snd_time = 60.0 - (sc + us*1e-6);
+    /* we have time until the end of the minute to do sounding */
+    /* minus a safety factor given in time_needed */
+    TimeReadClock(&yr,&mo,&dy,&hr,&mt,&sc,&us);
+    snd_time = 60.0 - (sc + us*1e-6);
 
-      while (snd_time-snd_intt > time_needed) {
+    while (snd_time-snd_intt > time_needed) {
 
-        /* set the beam */
-        bmnum = snd_bms[snd_bm_cnt] + odd_beams;
+      /* set the beam */
+      bmnum = snd_bms[snd_bm_cnt] + odd_beams;
 
-        /* snd_freq will be an array of frequencies to step through */
-        snd_freq = snd_freqs[snd_freq_cnt];
+      /* snd_freq will be an array of frequencies to step through */
+      snd_freq = snd_freqs[snd_freq_cnt];
 
-        /* the scanning code is here */
-        sprintf(logtxt,"Integrating SND beam:%d intt:%ds.%dus (%d:%d:%d:%d)",bmnum,intsc,intus,hr,mt,sc,us);
-        ErrLog(errlog.sock,progname,logtxt);
-        ErrLog(errlog.sock,progname,"Setting SND beam.");
-        SiteStartIntt(intsc,intus);
+      /* the scanning code is here */
+      sprintf(logtxt,"Integrating SND beam:%d intt:%ds.%dus (%d:%d:%d:%d)",bmnum,intsc,intus,hr,mt,sc,us);
+      ErrLog(errlog.sock,progname,logtxt);
+      ErrLog(errlog.sock,progname,"Setting SND beam.");
+      SiteStartIntt(intsc,intus);
 
-        ErrLog(errlog.sock, progname, "Doing SND clear frequency search.");
-        sprintf(logtxt, "FRQ: %d %d", snd_freq, snd_frqrng);
+      ErrLog(errlog.sock, progname, "Doing SND clear frequency search.");
+      sprintf(logtxt, "FRQ: %d %d", snd_freq, snd_frqrng);
+      ErrLog(errlog.sock,progname, logtxt);
+      tfreq = SiteFCLR(snd_freq, snd_freq + snd_frqrng);
+
+      sprintf(logtxt,"Transmitting SND on: %d (Noise=%g)",tfreq,noise);
+      ErrLog(errlog.sock, progname, logtxt);
+
+      nave = SiteIntegrate(lags);
+      if (nave < 0) {
+        sprintf(logtxt, "SND integration error: %d", nave);
         ErrLog(errlog.sock,progname, logtxt);
-        tfreq = SiteFCLR(snd_freq, snd_freq + snd_frqrng);
+        continue;
+      }
+      sprintf(logtxt,"Number of SND sequences: %d",nave);
+      ErrLog(errlog.sock,progname,logtxt);
 
-        sprintf(logtxt,"Transmitting SND on: %d (Noise=%g)",tfreq,noise);
-        ErrLog(errlog.sock, progname, logtxt);
+      OpsBuildPrm(prm,ptab,lags);
+      OpsBuildIQ(iq,&badtr);
+      OpsBuildRaw(raw);
+      FitACF(prm,raw,fblk,fit);
 
-        nave = SiteIntegrate(lags);
-        if (nave < 0) {
-          sprintf(logtxt, "SND integration error: %d", nave);
-          ErrLog(errlog.sock,progname, logtxt);
-          continue;
-        }
-        sprintf(logtxt,"Number of SND sequences: %d",nave);
-        ErrLog(errlog.sock,progname,logtxt);
+      ErrLog(errlog.sock, progname, "Sending SND messages.");
+      msg.num = 0;
+      msg.tsize = 0;
 
-        OpsBuildPrm(prm,ptab,lags);
-        OpsBuildIQ(iq,&badtr);
-        OpsBuildRaw(raw);
-        FitACF(prm,raw,fblk,fit);
+      tmpbuf=RadarParmFlatten(prm,&tmpsze);
+      RMsgSndAdd(&msg,tmpsze,tmpbuf,PRM_TYPE,0);
 
-        ErrLog(errlog.sock, progname, "Sending SND messages.");
-        msg.num = 0;
-        msg.tsize = 0;
+      tmpbuf=IQFlatten(iq,prm->nave,&tmpsze);
+      RMsgSndAdd(&msg,tmpsze,tmpbuf,IQ_TYPE,0);
 
-        tmpbuf=RadarParmFlatten(prm,&tmpsze);
-        RMsgSndAdd(&msg,tmpsze,tmpbuf,PRM_TYPE,0);
+      RMsgSndAdd(&msg,sizeof(unsigned int)*2*iq->tbadtr,
+             (unsigned char *) badtr,BADTR_TYPE,0);
 
-        tmpbuf=IQFlatten(iq,prm->nave,&tmpsze);
-        RMsgSndAdd(&msg,tmpsze,tmpbuf,IQ_TYPE,0);
+      RMsgSndAdd(&msg,strlen(sharedmemory)+1,
+             (unsigned char *) sharedmemory,IQS_TYPE,0);
 
-        RMsgSndAdd(&msg,sizeof(unsigned int)*2*iq->tbadtr,
-               (unsigned char *) badtr,BADTR_TYPE,0);
+      tmpbuf=RawFlatten(raw,prm->nrang,prm->mplgs,&tmpsze);
+      RMsgSndAdd(&msg,tmpsze,tmpbuf,RAW_TYPE,0);
 
-        RMsgSndAdd(&msg,strlen(sharedmemory)+1,
-               (unsigned char *) sharedmemory,IQS_TYPE,0);
+      tmpbuf=FitFlatten(fit,prm->nrang,&tmpsze);
+      RMsgSndAdd(&msg,tmpsze,tmpbuf,FIT_TYPE,0);
 
-        tmpbuf=RawFlatten(raw,prm->nrang,prm->mplgs,&tmpsze);
-        RMsgSndAdd(&msg,tmpsze,tmpbuf,RAW_TYPE,0);
+      RMsgSndAdd(&msg,strlen(progname)+1,(unsigned char *) progname,NME_TYPE,0);
 
-        tmpbuf=FitFlatten(fit,prm->nrang,&tmpsze);
-        RMsgSndAdd(&msg,tmpsze,tmpbuf,FIT_TYPE,0);
-
-        RMsgSndAdd(&msg,strlen(progname)+1,(unsigned char *) progname,NME_TYPE,0);
-
-        RMsgSndSend(task[RT_TASK].sock,&msg);
-        for (n=0;n<msg.num;n++) {
-          if (msg.data[n].type==PRM_TYPE) free(msg.ptr[n]);
-          if (msg.data[n].type==IQ_TYPE) free(msg.ptr[n]);
-          if (msg.data[n].type==RAW_TYPE) free(msg.ptr[n]);
-          if (msg.data[n].type==FIT_TYPE) free(msg.ptr[n]);
-        }
-
-        sprintf(logtxt, "SBC: %d  SFC: %d", snd_bm_cnt, snd_freq_cnt);
-        ErrLog(errlog.sock, progname, logtxt);
-
-        /* set the scan variable for the sounding mode data file only */
-        if ((bmnum == snd_bms[0]) && (snd_freq == snd_freqs[0])) {
-          prm->scan = 1;
-        } else {
-          prm->scan = 0;
-        }
-
-        /* save the sounding mode data */
-        write_snd_record(progname, prm, fit);
-
-        ErrLog(errlog.sock, progname, "Polling SND for exit.\n");
-        if (exitpoll !=0) break;
-
-        /* check for the end of a beam loop */
-        snd_freq_cnt++;
-        if (snd_freq_cnt >= snd_freqs_tot) {
-          /* reset the freq counter and increment the beam counter */
-          snd_freq_cnt = 0;
-          snd_bm_cnt++;
-          if (snd_bm_cnt >= snd_bms_tot) {
-            snd_bm_cnt = 0;
-            odd_beams = !odd_beams;
-          }
-        }
-
-        /* see if we have enough time for another go round */
-        TimeReadClock(&yr, &mo, &dy, &hr, &mt, &sc, &us);
-        snd_time = 60.0 - (sc + us*1e-6);
+      RMsgSndSend(task[RT_TASK].sock,&msg);
+      for (n=0;n<msg.num;n++) {
+        if (msg.data[n].type==PRM_TYPE) free(msg.ptr[n]);
+        if (msg.data[n].type==IQ_TYPE) free(msg.ptr[n]);
+        if (msg.data[n].type==RAW_TYPE) free(msg.ptr[n]);
+        if (msg.data[n].type==FIT_TYPE) free(msg.ptr[n]);
       }
 
-      /* now wait for the next normalscan */
-      ErrLog(errlog.sock,progname,"Waiting for scan boundary.");
+      sprintf(logtxt, "SBC: %d  SFC: %d", snd_bm_cnt, snd_freq_cnt);
+      ErrLog(errlog.sock, progname, logtxt);
 
-      intsc = def_intt_sc;
-      intus = def_intt_us;
-      nrang = def_nrang;
+      /* set the scan variable for the sounding mode data file only */
+      if ((bmnum == snd_bms[0]) && (snd_freq == snd_freqs[0])) {
+        prm->scan = 1;
+      } else {
+        prm->scan = 0;
+      }
 
-      SiteEndScan(scnsc,scnus);
+      /* save the sounding mode data */
+      write_snd_record(progname, prm, fit);
+
+      ErrLog(errlog.sock, progname, "Polling SND for exit.\n");
+
+      /* check for the end of a beam loop */
+      snd_freq_cnt++;
+      if (snd_freq_cnt >= snd_freqs_tot) {
+        /* reset the freq counter and increment the beam counter */
+        snd_freq_cnt = 0;
+        snd_bm_cnt++;
+        if (snd_bm_cnt >= snd_bms_tot) {
+          snd_bm_cnt = 0;
+          odd_beams = !odd_beams;
+        }
+      }
+
+      /* see if we have enough time for another go round */
+      TimeReadClock(&yr, &mo, &dy, &hr, &mt, &sc, &us);
+      snd_time = 60.0 - (sc + us*1e-6);
     }
 
-  } while (exitpoll == 0);
+    /* now wait for the next normalscan */
+    ErrLog(errlog.sock,progname,"Waiting for scan boundary.");
+
+    intsc = def_intt_sc;
+    intus = def_intt_us;
+    nrang = def_nrang;
+
+    SiteEndScan(scnsc,scnus);
+
+  } while (1);
 
   for (n=0; n<tnum; n++) RMsgSndClose(task[n].sock);
 

--- a/qnx6/normalsound.2.0/normalsound_fh.c
+++ b/qnx6/normalsound.2.0/normalsound_fh.c
@@ -580,7 +580,7 @@ int main(int argc,char *argv[])
           if (msg.data[n].type==FIT_TYPE) free(msg.ptr[n]);
         }
 
-        sprintf(logtxt, "SBC: %d  SFC: %d\n", snd_bm_cnt, snd_freq_cnt);
+        sprintf(logtxt, "SBC: %d  SFC: %d", snd_bm_cnt, snd_freq_cnt);
         ErrLog(errlog.sock, progname, logtxt);
 
         /* set the scan variable for the sounding mode data file only */
@@ -593,7 +593,7 @@ int main(int argc,char *argv[])
         /* save the sounding mode data */
         write_snd_record(progname, prm, fit);
 
-        ErrLog(errlog.sock, progname, "Polling SND for exit.");
+        ErrLog(errlog.sock, progname, "Polling SND for exit.\n");
         if (exitpoll !=0) break;
 
         /* check for the end of a beam loop */

--- a/ros.1.02/interleavesound.1.00/interleavesound.c
+++ b/ros.1.02/interleavesound.1.00/interleavesound.c
@@ -418,12 +418,16 @@ void main(int argc,char *argv[]) {
       }
     } while (1);
 
+
     if (exit_poll==0) {
       /* set the "sounder mode" scan variable */
       scan=-2;
 
       /* set the xcf variable to do cross-correlations (AOA) */
       xcf=1;
+
+      /* set the sounding mode integration time and number of ranges */
+      intt = snd_intt;
 
       /* setup the sounder mode integration time */
       /* determine the number of seconds we have for this mode  */
@@ -433,7 +437,6 @@ void main(int argc,char *argv[]) {
       snd_time = 60.0 - (sec+msec/1000.);
 
       while(snd_time-(float)snd_intt > time_needed) {
-        intt = snd_intt;
 
         /* set the beam */
         bmnum = snd_bms[snd_bm_cnt] + odd_beams;


### PR DESCRIPTION
The main purpose of this pull request is to increase the number of sequences during each sounding scan integration period by reducing the number of ranges for those radars which use more than the original default of 75 gates.  After tests at Blackstone (QNX4) and Christmas Valley East and West (QNX6) over the last two weeks, this change in `nrang` (and therefore the timing sequence) mid-control program has now been successfully demonstrated.

I know there is no real review procedure for control programs in this repository, but unless there are any strong objections I would like to merge this branch so that the changes are in place for the upcoming October 2021 Special Time frequency sounding experiment.